### PR TITLE
Fix orientation

### DIFF
--- a/LNNotificationsUI/LNNotificationsUI/LNNotificationBannerView.m
+++ b/LNNotificationsUI/LNNotificationsUI/LNNotificationBannerView.m
@@ -144,6 +144,7 @@ static const CGFloat LNNotificationRelativeLabelCollapse = 5.0 * 60.0;
 		_titleLabel.font = [UIFont boldSystemFontOfSize:13];
 		_titleLabel.textColor = style == LNNotificationBannerStyleDark ? [UIColor whiteColor] : [UIColor blackColor];
 		_titleLabel.translatesAutoresizingMaskIntoConstraints = NO;
+		_titleLabel.backgroundColor = [UIColor clearColor];
 		
 		[_notificationContentView addSubview:_titleLabel];
 		
@@ -152,6 +153,7 @@ static const CGFloat LNNotificationRelativeLabelCollapse = 5.0 * 60.0;
 		_messageLabel.textColor = style == LNNotificationBannerStyleDark ? [UIColor whiteColor] : [UIColor blackColor];
 		_messageLabel.translatesAutoresizingMaskIntoConstraints = NO;
 		_messageLabel.numberOfLines = 2;
+		_messageLabel.backgroundColor = [UIColor clearColor];
 		
 		[_notificationContentView addSubview:_messageLabel];
 		
@@ -166,6 +168,7 @@ static const CGFloat LNNotificationRelativeLabelCollapse = 5.0 * 60.0;
 		[_dateLabel setContentCompressionResistancePriority:1000 forAxis:UILayoutConstraintAxisVertical];
 		[_dateLabel setContentHuggingPriority:1000 forAxis:UILayoutConstraintAxisHorizontal];
 		[_dateLabel setContentHuggingPriority:1000 forAxis:UILayoutConstraintAxisVertical];
+		_dateLabel.backgroundColor = [UIColor clearColor];
 		
 		UIView<_LNBackgroundViewCommon>* dateBG;
 		if([UIVisualEffectView class])

--- a/LNNotificationsUI/LNNotificationsUI/LNNotificationBannerView.m
+++ b/LNNotificationsUI/LNNotificationsUI/LNNotificationBannerView.m
@@ -144,7 +144,6 @@ static const CGFloat LNNotificationRelativeLabelCollapse = 5.0 * 60.0;
 		_titleLabel.font = [UIFont boldSystemFontOfSize:13];
 		_titleLabel.textColor = style == LNNotificationBannerStyleDark ? [UIColor whiteColor] : [UIColor blackColor];
 		_titleLabel.translatesAutoresizingMaskIntoConstraints = NO;
-		_titleLabel.backgroundColor = [UIColor clearColor];
 		
 		[_notificationContentView addSubview:_titleLabel];
 		
@@ -153,7 +152,6 @@ static const CGFloat LNNotificationRelativeLabelCollapse = 5.0 * 60.0;
 		_messageLabel.textColor = style == LNNotificationBannerStyleDark ? [UIColor whiteColor] : [UIColor blackColor];
 		_messageLabel.translatesAutoresizingMaskIntoConstraints = NO;
 		_messageLabel.numberOfLines = 2;
-		_messageLabel.backgroundColor = [UIColor clearColor];
 		
 		[_notificationContentView addSubview:_messageLabel];
 		
@@ -168,7 +166,6 @@ static const CGFloat LNNotificationRelativeLabelCollapse = 5.0 * 60.0;
 		[_dateLabel setContentCompressionResistancePriority:1000 forAxis:UILayoutConstraintAxisVertical];
 		[_dateLabel setContentHuggingPriority:1000 forAxis:UILayoutConstraintAxisHorizontal];
 		[_dateLabel setContentHuggingPriority:1000 forAxis:UILayoutConstraintAxisVertical];
-		_dateLabel.backgroundColor = [UIColor clearColor];
 		
 		UIView<_LNBackgroundViewCommon>* dateBG;
 		if([UIVisualEffectView class])

--- a/LNNotificationsUI/LNNotificationsUI/LNNotificationBannerWindow.m
+++ b/LNNotificationsUI/LNNotificationsUI/LNNotificationBannerWindow.m
@@ -11,8 +11,6 @@
 #import "LNNotificationBannerView.h"
 #import "LNNotificationCenter.h"
 
-#define IS_IOS7 ([[[UIDevice currentDevice] systemVersion] floatValue] >= 7.0)
-
 static const NSTimeInterval LNNotificationAnimationDuration = 0.5;
 static const NSTimeInterval LNNotificationFullDuration = 5.0;
 static const NSTimeInterval LNNotificationCutOffDuration = 2.5;
@@ -164,50 +162,24 @@ extern NSString* const LNNotificationWasTappedNotification;
 		_topConstraint.constant = -LNNotificationViewHeight;
 		[self layoutIfNeeded];
 		
-		if (IS_IOS7)
-		{
-			[UIView animateWithDuration:LNNotificationAnimationDuration delay:delay usingSpringWithDamping:500 initialSpringVelocity:0 options:UIViewAnimationOptionCurveEaseInOut animations:^{
-				_topConstraint.constant = 0;
-				[self layoutIfNeeded];
-			} completion:^(BOOL finished) {
-				_lastShowDate = [NSDate date];
-				_notificationViewShown = YES;
-				
-				_pendingCompletionHandler = completionBlock;
-				
-				dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(LNNotificationCutOffDuration * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
-					if(_pendingCompletionHandler)
-					{
-						void (^prevPendingCompletionHandler)() = _pendingCompletionHandler;
-						_pendingCompletionHandler = nil;
-						prevPendingCompletionHandler();
-					}
-				});
-			}];
-		}
-		else
-		{
-			[UIView animateWithDuration:LNNotificationAnimationDuration delay:delay options:UIViewAnimationOptionCurveEaseInOut
-							 animations:^{
-								 _topConstraint.constant = 0;
-								 [self layoutIfNeeded];
-							 }
-							 completion:^(BOOL finished) {
-								 _lastShowDate = [NSDate date];
-								 _notificationViewShown = YES;
-								 
-								 _pendingCompletionHandler = completionBlock;
-								 
-								 dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(LNNotificationCutOffDuration * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
-									 if(_pendingCompletionHandler)
-									 {
-										 void (^prevPendingCompletionHandler)() = _pendingCompletionHandler;
-										 _pendingCompletionHandler = nil;
-										 prevPendingCompletionHandler();
-									 }
-								 });
-							 }];
-		}
+		[UIView animateWithDuration:LNNotificationAnimationDuration delay:delay usingSpringWithDamping:500 initialSpringVelocity:0 options:UIViewAnimationOptionCurveEaseInOut animations:^{
+			_topConstraint.constant = 0;
+			[self layoutIfNeeded];
+		} completion:^(BOOL finished) {
+			_lastShowDate = [NSDate date];
+			_notificationViewShown = YES;
+			
+			_pendingCompletionHandler = completionBlock;
+			
+			dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(LNNotificationCutOffDuration * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+				if(_pendingCompletionHandler)
+				{
+					void (^prevPendingCompletionHandler)() = _pendingCompletionHandler;
+					_pendingCompletionHandler = nil;
+					prevPendingCompletionHandler();
+				}
+			});
+		}];
 	}
 	else
 	{
@@ -220,52 +192,27 @@ extern NSString* const LNNotificationWasTappedNotification;
 		
 		[_notificationView.notificationContentView.superview insertSubview:snapshot belowSubview:_notificationView.notificationContentView];
 		
-		if (IS_IOS7)
-		{
-			[UIView animateWithDuration:0.75 * LNNotificationAnimationDuration delay:delay usingSpringWithDamping:500 initialSpringVelocity:0 options:UIViewAnimationOptionCurveEaseInOut animations:^{
-				frame.origin.y = 0;
-				_notificationView.notificationContentView.frame = frame;
-				snapshot.alpha = 0;
-			} completion:^(BOOL finished) {
-				[snapshot removeFromSuperview];
-				_lastShowDate = [NSDate date];
-				
-				_pendingCompletionHandler = completionBlock;
-				
-				dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(LNNotificationCutOffDuration * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
-					if(_pendingCompletionHandler)
-					{
-						void (^prevPendingCompletionHandler)() = _pendingCompletionHandler;
-						_pendingCompletionHandler = nil;
-						prevPendingCompletionHandler();
-					}
-				});
-			}];
-		}
-		else
-		{
-			[UIView animateWithDuration:0.75 * LNNotificationAnimationDuration delay:delay options:UIViewAnimationOptionCurveEaseInOut
-							 animations:^{
-								 frame.origin.y = 0;
-								 _notificationView.notificationContentView.frame = frame;
-								 snapshot.alpha = 0;
-							 }
-							 completion:^(BOOL finished) {
-								 [snapshot removeFromSuperview];
-								 _lastShowDate = [NSDate date];
-								 
-								 _pendingCompletionHandler = completionBlock;
-								 
-								 dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(LNNotificationCutOffDuration * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
-									 if(_pendingCompletionHandler)
-									 {
-										 void (^prevPendingCompletionHandler)() = _pendingCompletionHandler;
-										 _pendingCompletionHandler = nil;
-										 prevPendingCompletionHandler();
-									 }
-								 });
-							 }];
-		}
+		
+		
+		[UIView animateWithDuration:0.75 * LNNotificationAnimationDuration delay:delay usingSpringWithDamping:500 initialSpringVelocity:0 options:UIViewAnimationOptionCurveEaseInOut animations:^{
+			frame.origin.y = 0;
+			_notificationView.notificationContentView.frame = frame;
+			snapshot.alpha = 0;
+		} completion:^(BOOL finished) {
+			[snapshot removeFromSuperview];
+			_lastShowDate = [NSDate date];
+			
+			_pendingCompletionHandler = completionBlock;
+			
+			dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(LNNotificationCutOffDuration * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+				if(_pendingCompletionHandler)
+				{
+					void (^prevPendingCompletionHandler)() = _pendingCompletionHandler;
+					_pendingCompletionHandler = nil;
+					prevPendingCompletionHandler();
+				}
+			});
+		}];
 	}
 }
 
@@ -301,44 +248,21 @@ extern NSString* const LNNotificationWasTappedNotification;
 		_notificationViewShown = NO;
 	});
 	
-	if (IS_IOS7)
-	{
-		[UIView animateWithDuration:LNNotificationAnimationDuration delay:delay usingSpringWithDamping:500 initialSpringVelocity:0 options:UIViewAnimationOptionCurveEaseInOut | UIViewAnimationOptionBeginFromCurrentState animations:^{
-			_topConstraint.constant = -LNNotificationViewHeight;
-			[self layoutIfNeeded];
-		} completion:^(BOOL finished) {
-			_lastShowDate = nil;
-			_notificationViewShown = NO;
-			[_notificationView configureForNotification:nil];
-			
-			if(_pendingCompletionHandler)
-			{
-				void (^prevPendingCompletionHandler)() = _pendingCompletionHandler;
-				_pendingCompletionHandler = nil;
-				prevPendingCompletionHandler();
-			}
-		}];
-	}
-	else
-	{
-		[UIView animateWithDuration:LNNotificationAnimationDuration delay:delay options:UIViewAnimationOptionCurveEaseInOut
-						 animations:^{
-							 _topConstraint.constant = -LNNotificationViewHeight;
-							 [self layoutIfNeeded];
-						 }
-						 completion:^(BOOL finished) {
-							 _lastShowDate = nil;
-							 _notificationViewShown = NO;
-							 [_notificationView configureForNotification:nil];
-							 
-							 if(_pendingCompletionHandler)
-							 {
-								 void (^prevPendingCompletionHandler)() = _pendingCompletionHandler;
-								 _pendingCompletionHandler = nil;
-								 prevPendingCompletionHandler();
-							 }
-						 }];
-	}
+	[UIView animateWithDuration:LNNotificationAnimationDuration delay:delay usingSpringWithDamping:500 initialSpringVelocity:0 options:UIViewAnimationOptionCurveEaseInOut | UIViewAnimationOptionBeginFromCurrentState animations:^{
+		_topConstraint.constant = -LNNotificationViewHeight;
+		[self layoutIfNeeded];
+	} completion:^(BOOL finished) {
+		_lastShowDate = nil;
+		_notificationViewShown = NO;
+		[_notificationView configureForNotification:nil];
+		
+		if(_pendingCompletionHandler)
+		{
+			void (^prevPendingCompletionHandler)() = _pendingCompletionHandler;
+			_pendingCompletionHandler = nil;
+			prevPendingCompletionHandler();
+		}
+	}];
 }
 
 - (UIView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event

--- a/LNNotificationsUI/LNNotificationsUI/LNNotificationBannerWindow.m
+++ b/LNNotificationsUI/LNNotificationsUI/LNNotificationBannerWindow.m
@@ -11,6 +11,8 @@
 #import "LNNotificationBannerView.h"
 #import "LNNotificationCenter.h"
 
+#define IS_IOS7 ([[[UIDevice currentDevice] systemVersion] floatValue] >= 7.0)
+
 static const NSTimeInterval LNNotificationAnimationDuration = 0.5;
 static const NSTimeInterval LNNotificationFullDuration = 5.0;
 static const NSTimeInterval LNNotificationCutOffDuration = 2.5;
@@ -162,24 +164,50 @@ extern NSString* const LNNotificationWasTappedNotification;
 		_topConstraint.constant = -LNNotificationViewHeight;
 		[self layoutIfNeeded];
 		
-		[UIView animateWithDuration:LNNotificationAnimationDuration delay:delay usingSpringWithDamping:500 initialSpringVelocity:0 options:UIViewAnimationOptionCurveEaseInOut animations:^{
-			_topConstraint.constant = 0;
-			[self layoutIfNeeded];
-		} completion:^(BOOL finished) {
-			_lastShowDate = [NSDate date];
-			_notificationViewShown = YES;
-			
-			_pendingCompletionHandler = completionBlock;
-			
-			dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(LNNotificationCutOffDuration * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
-				if(_pendingCompletionHandler)
-				{
-					void (^prevPendingCompletionHandler)() = _pendingCompletionHandler;
-					_pendingCompletionHandler = nil;
-					prevPendingCompletionHandler();
-				}
-			});
-		}];
+		if (IS_IOS7)
+		{
+			[UIView animateWithDuration:LNNotificationAnimationDuration delay:delay usingSpringWithDamping:500 initialSpringVelocity:0 options:UIViewAnimationOptionCurveEaseInOut animations:^{
+				_topConstraint.constant = 0;
+				[self layoutIfNeeded];
+			} completion:^(BOOL finished) {
+				_lastShowDate = [NSDate date];
+				_notificationViewShown = YES;
+				
+				_pendingCompletionHandler = completionBlock;
+				
+				dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(LNNotificationCutOffDuration * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+					if(_pendingCompletionHandler)
+					{
+						void (^prevPendingCompletionHandler)() = _pendingCompletionHandler;
+						_pendingCompletionHandler = nil;
+						prevPendingCompletionHandler();
+					}
+				});
+			}];
+		}
+		else
+		{
+			[UIView animateWithDuration:LNNotificationAnimationDuration delay:delay options:UIViewAnimationOptionCurveEaseInOut
+							 animations:^{
+								 _topConstraint.constant = 0;
+								 [self layoutIfNeeded];
+							 }
+							 completion:^(BOOL finished) {
+								 _lastShowDate = [NSDate date];
+								 _notificationViewShown = YES;
+								 
+								 _pendingCompletionHandler = completionBlock;
+								 
+								 dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(LNNotificationCutOffDuration * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+									 if(_pendingCompletionHandler)
+									 {
+										 void (^prevPendingCompletionHandler)() = _pendingCompletionHandler;
+										 _pendingCompletionHandler = nil;
+										 prevPendingCompletionHandler();
+									 }
+								 });
+							 }];
+		}
 	}
 	else
 	{
@@ -192,27 +220,52 @@ extern NSString* const LNNotificationWasTappedNotification;
 		
 		[_notificationView.notificationContentView.superview insertSubview:snapshot belowSubview:_notificationView.notificationContentView];
 		
-		
-		
-		[UIView animateWithDuration:0.75 * LNNotificationAnimationDuration delay:delay usingSpringWithDamping:500 initialSpringVelocity:0 options:UIViewAnimationOptionCurveEaseInOut animations:^{
-			frame.origin.y = 0;
-			_notificationView.notificationContentView.frame = frame;
-			snapshot.alpha = 0;
-		} completion:^(BOOL finished) {
-			[snapshot removeFromSuperview];
-			_lastShowDate = [NSDate date];
-			
-			_pendingCompletionHandler = completionBlock;
-			
-			dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(LNNotificationCutOffDuration * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
-				if(_pendingCompletionHandler)
-				{
-					void (^prevPendingCompletionHandler)() = _pendingCompletionHandler;
-					_pendingCompletionHandler = nil;
-					prevPendingCompletionHandler();
-				}
-			});
-		}];
+		if (IS_IOS7)
+		{
+			[UIView animateWithDuration:0.75 * LNNotificationAnimationDuration delay:delay usingSpringWithDamping:500 initialSpringVelocity:0 options:UIViewAnimationOptionCurveEaseInOut animations:^{
+				frame.origin.y = 0;
+				_notificationView.notificationContentView.frame = frame;
+				snapshot.alpha = 0;
+			} completion:^(BOOL finished) {
+				[snapshot removeFromSuperview];
+				_lastShowDate = [NSDate date];
+				
+				_pendingCompletionHandler = completionBlock;
+				
+				dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(LNNotificationCutOffDuration * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+					if(_pendingCompletionHandler)
+					{
+						void (^prevPendingCompletionHandler)() = _pendingCompletionHandler;
+						_pendingCompletionHandler = nil;
+						prevPendingCompletionHandler();
+					}
+				});
+			}];
+		}
+		else
+		{
+			[UIView animateWithDuration:0.75 * LNNotificationAnimationDuration delay:delay options:UIViewAnimationOptionCurveEaseInOut
+							 animations:^{
+								 frame.origin.y = 0;
+								 _notificationView.notificationContentView.frame = frame;
+								 snapshot.alpha = 0;
+							 }
+							 completion:^(BOOL finished) {
+								 [snapshot removeFromSuperview];
+								 _lastShowDate = [NSDate date];
+								 
+								 _pendingCompletionHandler = completionBlock;
+								 
+								 dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(LNNotificationCutOffDuration * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+									 if(_pendingCompletionHandler)
+									 {
+										 void (^prevPendingCompletionHandler)() = _pendingCompletionHandler;
+										 _pendingCompletionHandler = nil;
+										 prevPendingCompletionHandler();
+									 }
+								 });
+							 }];
+		}
 	}
 }
 
@@ -248,21 +301,44 @@ extern NSString* const LNNotificationWasTappedNotification;
 		_notificationViewShown = NO;
 	});
 	
-	[UIView animateWithDuration:LNNotificationAnimationDuration delay:delay usingSpringWithDamping:500 initialSpringVelocity:0 options:UIViewAnimationOptionCurveEaseInOut | UIViewAnimationOptionBeginFromCurrentState animations:^{
-		_topConstraint.constant = -LNNotificationViewHeight;
-		[self layoutIfNeeded];
-	} completion:^(BOOL finished) {
-		_lastShowDate = nil;
-		_notificationViewShown = NO;
-		[_notificationView configureForNotification:nil];
-		
-		if(_pendingCompletionHandler)
-		{
-			void (^prevPendingCompletionHandler)() = _pendingCompletionHandler;
-			_pendingCompletionHandler = nil;
-			prevPendingCompletionHandler();
-		}
-	}];
+	if (IS_IOS7)
+	{
+		[UIView animateWithDuration:LNNotificationAnimationDuration delay:delay usingSpringWithDamping:500 initialSpringVelocity:0 options:UIViewAnimationOptionCurveEaseInOut | UIViewAnimationOptionBeginFromCurrentState animations:^{
+			_topConstraint.constant = -LNNotificationViewHeight;
+			[self layoutIfNeeded];
+		} completion:^(BOOL finished) {
+			_lastShowDate = nil;
+			_notificationViewShown = NO;
+			[_notificationView configureForNotification:nil];
+			
+			if(_pendingCompletionHandler)
+			{
+				void (^prevPendingCompletionHandler)() = _pendingCompletionHandler;
+				_pendingCompletionHandler = nil;
+				prevPendingCompletionHandler();
+			}
+		}];
+	}
+	else
+	{
+		[UIView animateWithDuration:LNNotificationAnimationDuration delay:delay options:UIViewAnimationOptionCurveEaseInOut
+						 animations:^{
+							 _topConstraint.constant = -LNNotificationViewHeight;
+							 [self layoutIfNeeded];
+						 }
+						 completion:^(BOOL finished) {
+							 _lastShowDate = nil;
+							 _notificationViewShown = NO;
+							 [_notificationView configureForNotification:nil];
+							 
+							 if(_pendingCompletionHandler)
+							 {
+								 void (^prevPendingCompletionHandler)() = _pendingCompletionHandler;
+								 _pendingCompletionHandler = nil;
+								 prevPendingCompletionHandler();
+							 }
+						 }];
+	}
 }
 
 - (UIView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event

--- a/LNNotificationsUI/LNNotificationsUI/LNNotificationBannerWindow.m
+++ b/LNNotificationsUI/LNNotificationsUI/LNNotificationBannerWindow.m
@@ -33,6 +33,36 @@ extern NSString* const LNNotificationWasTappedNotification;
 	return [[UIApplication sharedApplication] statusBarStyle];
 }
 
+- (BOOL)shouldAutorotate
+{
+	return YES;
+}
+
+- (NSUInteger)supportedInterfaceOrientations
+{
+	UIInterfaceOrientation orientation = [UIApplication sharedApplication].statusBarOrientation;
+	if (orientation == UIInterfaceOrientationPortrait)
+		return UIInterfaceOrientationMaskPortrait;
+	else if (orientation == UIInterfaceOrientationPortraitUpsideDown)
+		return UIInterfaceOrientationMaskPortraitUpsideDown;
+	else if (orientation == UIInterfaceOrientationLandscapeLeft)
+		return UIInterfaceOrientationMaskLandscapeLeft;
+	else if (orientation == UIInterfaceOrientationLandscapeRight)
+		return UIInterfaceOrientationMaskLandscapeRight;
+	return UIInterfaceOrientationMaskAll;
+}
+
+- (UIInterfaceOrientation)preferredInterfaceOrientationForPresentation
+{
+	UIInterfaceOrientation orientation = [UIApplication sharedApplication].statusBarOrientation;
+	return orientation;
+}
+
+- (BOOL)prefersStatusBarHidden
+{
+	return NO;
+}
+
 @end
 
 @implementation LNNotificationBannerWindow

--- a/LNNotificationsUI/LNNotificationsUI/LNNotificationCenter.m
+++ b/LNNotificationsUI/LNNotificationsUI/LNNotificationCenter.m
@@ -205,6 +205,8 @@ NSString* const LNNotificationWasTappedNotification = @"LNNotificationWasTappedN
 		[self _handleBannerCanChange];
 		
 		[self _handlePendingNotifications];
+		
+		_notificationWindow = nil;
 	};
 	
 	if(_pendingNotifications.count == 0)


### PR DESCRIPTION
I create a new branch to pull request.

Make the orientation of LNNotificationBannerWindow changed base on statusBarOrientation
Sometimes, I hope the UIViewController force landscape. When trigger the LNNotification, it maybe portrait or landscape base on device. The LNNotification's Orientation is different with the UIViewController. If the LNNotification's Orientation is the same with the statusbar, the problem can be solved.