### PR TITLE
Fix Orientation

### DIFF
--- a/LNNotificationsUI/LNNotificationsUI/LNNotificationBannerWindow.m
+++ b/LNNotificationsUI/LNNotificationsUI/LNNotificationBannerWindow.m
@@ -33,6 +33,36 @@ extern NSString* const LNNotificationWasTappedNotification;
 	return [[UIApplication sharedApplication] statusBarStyle];
 }
 
+- (BOOL)shouldAutorotate
+{
+	return YES;
+}
+
+- (NSUInteger)supportedInterfaceOrientations
+{
+	UIInterfaceOrientation orientation = [UIApplication sharedApplication].statusBarOrientation;
+	if (orientation == UIInterfaceOrientationPortrait)
+		return UIInterfaceOrientationMaskPortrait;
+	else if (orientation == UIInterfaceOrientationPortraitUpsideDown)
+		return UIInterfaceOrientationMaskPortraitUpsideDown;
+	else if (orientation == UIInterfaceOrientationLandscapeLeft)
+		return UIInterfaceOrientationMaskLandscapeLeft;
+	else if (orientation == UIInterfaceOrientationLandscapeRight)
+		return UIInterfaceOrientationMaskLandscapeRight;
+	return UIInterfaceOrientationMaskAll;
+}
+
+- (UIInterfaceOrientation)preferredInterfaceOrientationForPresentation
+{
+	UIInterfaceOrientation orientation = [UIApplication sharedApplication].statusBarOrientation;
+	return orientation;
+}
+
+- (BOOL)prefersStatusBarHidden
+{
+	return NO;
+}
+
 @end
 
 @implementation LNNotificationBannerWindow


### PR DESCRIPTION
It looks github can not create a branch from history. So I re-folks, and pull request.

---
Make the orientation of LNNotificationBannerWindow changed base on
statusBarOrientation
Sometimes, I hope the UIViewController force landscape or portrait. When trigger
the LNNotification, it maybe portrait or landscape base on device. The
LNNotification's Orientation is different with the UIViewController. If
the LNNotification's Orientation is the same with the statusbar, the
problem can be solved. 
If the statusbar is hidden, the statusbar's orientation is still valid. The UIViewController' UI is also OK.

---
How to recurrence

Add the following code to LNNotificationsUIDemo/ViewController.m, in order to force ViewController Portrait.  The problem will happen when the device's orientation changed.

- (UIInterfaceOrientation)preferredInterfaceOrientationForPresentation
{
	return UIInterfaceOrientationPortrait;
}

- (BOOL)shouldAutorotate
{
	return YES;
}

- (NSUInteger)supportedInterfaceOrientations
{
	return UIInterfaceOrientationMaskPortrait;
}
