### PR TITLE
Fix Xcode 7 warning

### DIFF
--- a/LNNotificationsUI/LNNotificationsUI/LNNotification.m
+++ b/LNNotificationsUI/LNNotificationsUI/LNNotification.m
@@ -57,6 +57,11 @@
 	return [[LNNotification alloc] initWithTitle:title message:message icon:icon date:date];
 }
 
+- (instancetype)init
+{
+    return [self initWithTitle:nil message:nil icon:nil date:[NSDate date]];
+}
+
 - (instancetype)initWithMessage:(NSString*)message
 {
 	return [self initWithTitle:nil message:message icon:nil date:[NSDate date]];


### PR DESCRIPTION
Current build generated the warning: “Method override for the
designated initializer of the superclass ‘init’ not found”.

According to Apple Docs: “If a class provides one or more designated
initializers, it must implement all of the designated initializers of
its superclass.”

I have added an override for the superclass designated initializer
(init) which calls your designated initializer with nil parameters. If
you prefer to make init unavailable you could add to there header
instead:

- (instancetype)init NS_UNAVAILABLE;

It’s a judgement call which way to go.